### PR TITLE
Improve solution to exercise 01_09

### DIFF
--- a/solucoes/01/09.md
+++ b/solucoes/01/09.md
@@ -120,7 +120,7 @@ namespace Exercise09
                     if (matrix[i, j].Value != key)
                         continue;
 
-                    if (CheckLines(matrix, index: (row: i, column: j)))
+                    if (CheckLines(matrix, index: new Pos(i, j), key))
                         return true;
                 }
             }
@@ -129,76 +129,85 @@ namespace Exercise09
         }
 
         // Checks lines from given index
-        private bool CheckLines(int?[,] matrix, (int row, int column) index)
+        private bool CheckLines(int?[,] matrix, Pos index, int key)
         {
             int count = 0;
             int columns = matrix.GetLength(1);
             int rows = matrix.GetLength(0);
+            bool hasColumnSpace = columns - 4 >= index.Column;
+            bool hasRowSpace = rows - 4 >= index.Row;
 
             // Check right
-            // Check for available space first
-            if (columns - index.column >= 4)
+            for (int i = index.Column; hasColumnSpace; i++)
             {
-                for (int i = index.column; i < columns; i++)
+                if (key == matrix[index.Row, i].Value)
                 {
-                    if (matrix[index.row, index.column].Value == matrix[index.row, i].Value)
-                        count++;
-                    else
-                        break;
-                }
+                    count++;
 
-                if (count >= 4)
-                    return true;
+                    if (count >= 4)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    count = 0;
+                    break;
+                }
             }
 
             // Check down
-            // Check for available space first
-            if (rows - index.row >= 4)
+            for (int i = index.Row; hasRowSpace; i++)
             {
-                count = 0;
-                for (int i = index.row; i < rows; i++)
+                if (key == matrix[i, index.Column].Value)
                 {
-                    if (matrix[index.row, index.column].Value == matrix[i, index.column].Value)
-                        count++;
-                    else
-                        break;
-                }
+                    count++;
 
-                if (count >= 4)
-                    return true;
+                    if (count >= 4)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    count = 0;
+                    break;
+                }
             }
 
             // Check diagonal down right
-            // Check for available space first
-            if (rows - index.row >= 4 && columns - index.column >= 4)
+            for (int i = index.Row, k = index.Column; hasColumnSpace && hasRowSpace; i++, k++)
             {
-                count = 0;
-                for (int i = index.row, k = index.column; i < rows && k < columns; i++, k++)
+                if (key == matrix[i, k].Value)
                 {
-                    if (matrix[index.row, index.column].Value == matrix[i, k].Value)
-                        count++;
-                    else
-                        break;
-                }
+                    count++;
 
-                if (count >= 4)
-                    return true;
+                    if (count >= 4)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    count = 0;
+                    break;
+                }
             }
 
             // Check diagonal up right
-            // Check for available space first
-            if (index.row >= 3 && columns - index.column >= 4)
+            for (int i = index.Row, k = index.Column; index.Row >= 3 && hasColumnSpace; i--, k++)
             {
-                count = 0;
-                for (int i = index.row, k = index.column; i >= 0 && k < columns; i--, k++)
+                if (key == matrix[i, k].Value)
                 {
-                    if (matrix[index.row, index.column].Value == matrix[i, k].Value)
-                        count++;
-                    else
-                        break;
-                }
+                    count++;
 
-                return count >= 4;
+                    if (count >= 4)
+                    {
+                        return true;
+                    }
+                }
+                else
+                    break;
             }
 
             return false;
@@ -275,6 +284,25 @@ namespace Exercise09
                     }
                 }
             }
+        }
+    }
+}
+```
+
+Struct Pos:
+
+```csharp
+namespace Exercise09
+{
+    public struct Pos
+    {
+        public int Row { get; }
+        public int Column { get; }
+
+        public Pos(int row, int column)
+        {
+            Row = row;
+            Column = column;
         }
     }
 }

--- a/solucoes/01/09.md
+++ b/solucoes/01/09.md
@@ -30,14 +30,15 @@ namespace Exercise09
     {
         static void Main(string[] args)
         {
-            string[] splitHolder;
-            string input, errorMsg = null;
+            string errorMsg = null;
             int?[,] matrix = null;
             int? key = null;
             Checker checker;
 
             while (matrix == null)
             {
+                string[] splitHolder;
+
                 Console.Clear();
 
                 if (!string.IsNullOrEmpty(errorMsg))
@@ -54,7 +55,14 @@ namespace Exercise09
                 else if (int.TryParse(splitHolder[0], out int rows) &&
                     int.TryParse(splitHolder[1], out int columns))
                 {
-                    matrix = new int?[rows, columns];
+                    if (rows < 4 && columns < 4)
+                    {
+                        errorMsg = "Minimum size is 4x4";
+                    }
+                    else
+                    {
+                        matrix = new int?[rows, columns];
+                    }
                 }
                 else
                 {
@@ -67,6 +75,8 @@ namespace Exercise09
             errorMsg = null;
             while (key == null)
             {
+                string input;
+
                 Console.Clear();
 
                 if (!string.IsNullOrEmpty(errorMsg))
@@ -110,7 +120,7 @@ namespace Exercise09
                     if (matrix[i, j].Value != key)
                         continue;
 
-                    if (CheckLines(matrix, (i, j)))
+                    if (CheckLines(matrix, index: (row: i, column: j)))
                         return true;
                 }
             }
@@ -126,54 +136,72 @@ namespace Exercise09
             int rows = matrix.GetLength(0);
 
             // Check right
-            for (int i = index.column; i < columns; i++)
+            // Check for available space first
+            if (columns - index.column >= 4)
             {
-                if (matrix[index.row, index.column].Value == matrix[index.row, i].Value)
-                    count++;
-                else
-                    break;
-            }
+                for (int i = index.column; i < columns; i++)
+                {
+                    if (matrix[index.row, index.column].Value == matrix[index.row, i].Value)
+                        count++;
+                    else
+                        break;
+                }
 
-            if (count >= 4)
-                return true;
+                if (count >= 4)
+                    return true;
+            }
 
             // Check down
-            count = 0;
-            for (int i = index.row; i < rows; i++)
+            // Check for available space first
+            if (rows - index.row >= 4)
             {
-                if (matrix[index.row, index.column].Value == matrix[i, index.column].Value)
-                    count++;
-                else
-                    break;
-            }
+                count = 0;
+                for (int i = index.row; i < rows; i++)
+                {
+                    if (matrix[index.row, index.column].Value == matrix[i, index.column].Value)
+                        count++;
+                    else
+                        break;
+                }
 
-            if (count >= 4)
-                return true;
+                if (count >= 4)
+                    return true;
+            }
 
             // Check diagonal down right
-            count = 0;
-            for (int i = index.row, k = index.column; i < rows && k < columns; i++, k++)
+            // Check for available space first
+            if (rows - index.row >= 4 && columns - index.column >= 4)
             {
-                if (matrix[index.row, index.column].Value == matrix[i, k].Value)
-                    count++;
-                else
-                    break;
-            }
+                count = 0;
+                for (int i = index.row, k = index.column; i < rows && k < columns; i++, k++)
+                {
+                    if (matrix[index.row, index.column].Value == matrix[i, k].Value)
+                        count++;
+                    else
+                        break;
+                }
 
-            if (count >= 4)
-                return true;
+                if (count >= 4)
+                    return true;
+            }
 
             // Check diagonal up right
-            count = 0;
-            for (int i = index.row, k = index.column; i >= 0 && k < columns; i--, k++)
+            // Check for available space first
+            if (index.row >= 3 && columns - index.column >= 4)
             {
-                if (matrix[index.row, index.column].Value == matrix[i, k].Value)
-                    count++;
-                else
-                    break;
+                count = 0;
+                for (int i = index.row, k = index.column; i >= 0 && k < columns; i--, k++)
+                {
+                    if (matrix[index.row, index.column].Value == matrix[i, k].Value)
+                        count++;
+                    else
+                        break;
+                }
+
+                return count >= 4;
             }
 
-            return count >= 4;
+            return false;
         }
 
         // Checks if every value in matrix is set


### PR DESCRIPTION
Eu decidi aplicar as recomendações do professor. Menos a questão do tuplo. Eu acho que refletir a relação entre os dois index do array bidimensional faz todo o sentido neste caso. Seja como for, para aumentar a legibilidade eu adicionei o nome dos argumentos quando invoco o método.

Interessantemente, embora faça algum sentido verificar se existe tamanho suficiente para encontrar uma linha válida, este código é mais lento. Eu usei System.Diagnostics para medir o tempo que demoram os dois metodos (com e sem checks) e o com checks demorou sempre mais. Houve um aumento de cerca de 30% de tempo. Também decidi medir o impacto de usar um tuplo como argumento e nos meus testes foi sempre mais rápido com o tuplo do que usar dois argumentos int.